### PR TITLE
support for relative links and images

### DIFF
--- a/src/main/java/net/nicoulaj/idea/markdown/editor/MarkdownEditorKit.java
+++ b/src/main/java/net/nicoulaj/idea/markdown/editor/MarkdownEditorKit.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2011 Julien Nicoulaud <julien.nicoulaud@gmail.com>
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package net.nicoulaj.idea.markdown.editor;
+
+import com.intellij.ide.DataManager;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.actionSystem.DataKeys;
+import com.intellij.openapi.actionSystem.DataProvider;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.util.AsyncResult;
+import com.intellij.openapi.vfs.VirtualFile;
+
+import javax.swing.*;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.Element;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.View;
+import javax.swing.text.ViewFactory;
+import javax.swing.text.html.HTML;
+import javax.swing.text.html.HTMLEditorKit;
+import javax.swing.text.html.ImageView;
+
+import java.awt.*;
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static net.nicoulaj.idea.markdown.editor.MarkdownPathResolver.*;
+
+/**
+ * <p>MarkdownViewFactory</p>
+ *
+ * @author Roger Grantham
+ */
+public class MarkdownEditorKit extends HTMLEditorKit {
+
+	@Override
+	public Object clone() {
+		super.clone();
+		return new MarkdownEditorKit();
+	}
+
+
+	@Override
+	public ViewFactory getViewFactory() {
+		return new MarkdownViewFactory();
+	}
+
+
+	private static class MarkdownViewFactory extends HTMLFactory {
+		@Override
+		public View create(Element elem) {
+			final Object tag = elem.getAttributes().getAttribute(StyleConstants.NameAttribute);
+			if (HTML.Tag.IMG.equals(tag)){
+				final AttributeSet atts = elem.getAttributes();
+				final Object src = atts.getAttribute(HTML.Attribute.SRC);
+				//final VirtualFile imageTarget = resolveRelativePath(src.toString());
+				//final String imagePath = imageTarget.getPath();
+				return new MarkdownImageView(elem);
+			} else {
+				return super.create(elem);
+			}
+		}
+	}
+
+	private static class MarkdownImageView extends ImageView {
+
+		private MarkdownImageView(Element elem) {
+			super(elem);
+			this.setLoadsSynchronously(true);
+		}
+
+
+
+		@Override
+		public Image getImage() {
+			return super.getImage();
+		}
+
+		@Override
+		public URL getImageURL() {
+			URL imageURL = super.getImageURL();
+			if (imageURL == null){
+				final String src = (String)getElement().getAttributes().getAttribute(HTML.Attribute.SRC);
+				VirtualFile localImage = resolveRelativePath(src);
+				try {
+					if (localImage != null && localImage.exists()){
+						imageURL = new File(localImage.getPath()).toURI().toURL();
+					}
+				} catch (MalformedURLException e) {
+					imageURL = null;
+				}
+			}
+			return imageURL;
+		}
+
+	}
+}

--- a/src/main/java/net/nicoulaj/idea/markdown/editor/MarkdownLinkListener.java
+++ b/src/main/java/net/nicoulaj/idea/markdown/editor/MarkdownLinkListener.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2011 Julien Nicoulaud <julien.nicoulaud@gmail.com>
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package net.nicoulaj.idea.markdown.editor;
+
+import com.intellij.ide.DataManager;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.actionSystem.DataKeys;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.fileEditor.FileEditor;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.fileEditor.OpenFileDescriptor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.AsyncResult;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VirtualFileManager;
+import com.intellij.openapi.vfs.VirtualFileSystem;
+import com.intellij.openapi.vfs.ex.http.HttpFileSystem;
+import com.intellij.ui.BrowserHyperlinkListener;
+
+import javax.swing.event.HyperlinkEvent;
+import javax.swing.event.HyperlinkListener;
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static net.nicoulaj.idea.markdown.editor.MarkdownPathResolver.*;
+
+/**
+ * <p>MarkdownLinkListener is able to resolve the following types of links and open them in a new editor window:</p>
+ * <ul>
+ *     <li>Local absolute paths e.g. <code>/absolute/path/to/file</code>
+ *     <li>local relative paths, e.g. <code>./some/relative/file</code>, <code>../../some/other/file</code>
+ *     <li>references to classes within the project, e.g. <code>net.nicoulaj.idea.markdown.editor.MarkdownLinkListener</code>
+ * </ul>
+ *
+ * <p>MarkdownLinkListener will attempt to open non-local resources in a web browser.</p>
+ *
+ * @author Roger Grantham
+ */
+public class MarkdownLinkListener implements HyperlinkListener {
+
+	final BrowserHyperlinkListener browserLinkListener = new BrowserHyperlinkListener();
+
+	public void hyperlinkUpdate(HyperlinkEvent e) {
+		if (HyperlinkEvent.EventType.ACTIVATED == e.getEventType()){
+			// try to get a URL from the event
+			URL target = e.getURL();
+			if (target == null){
+				try {
+					target = new File(e.getDescription()).toURI().toURL();
+				} catch (MalformedURLException e1) {
+					// can't find the link target, give up...
+					return;
+				}
+			}
+			VirtualFileSystem vfs = VirtualFileManager.getInstance().getFileSystem(target.getProtocol());
+			if (vfs instanceof HttpFileSystem){
+				browserLinkListener.hyperlinkUpdate(e);
+			} else {
+				final AsyncResult<DataContext> dataContext = DataManager.getInstance().getDataContextFromFocus();
+				final Project project = DataKeys.PROJECT.getData(dataContext.getResult());
+				VirtualFile virtualTarget = findVirtualFile(target);
+				if (virtualTarget == null || !virtualTarget.exists()){
+					virtualTarget = resolveRelativePath(e.getDescription());
+					}
+
+				if (virtualTarget == null){ // Okay, try as if the link target is a class reference
+					virtualTarget = resolveClassReference(e.getDescription());
+					}
+
+				if (virtualTarget != null){
+					FileEditorManager.getInstance(project).openFile(virtualTarget, true);
+				}
+			}
+		}
+	}
+
+}

--- a/src/main/java/net/nicoulaj/idea/markdown/editor/MarkdownPathResolver.java
+++ b/src/main/java/net/nicoulaj/idea/markdown/editor/MarkdownPathResolver.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2011 Julien Nicoulaud <julien.nicoulaud@gmail.com>
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package net.nicoulaj.idea.markdown.editor;
+
+import com.intellij.ide.DataManager;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.actionSystem.DataKeys;
+import com.intellij.openapi.actionSystem.DataProvider;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.util.AsyncResult;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VirtualFileManager;
+import com.intellij.openapi.vfs.VirtualFileSystem;
+import com.intellij.openapi.vfs.ex.http.HttpFileSystem;
+import com.intellij.psi.JavaPsiFacade;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.search.GlobalSearchScope;
+
+import java.net.URL;
+
+/**
+ * <p>MarkdownPathResolver</p>
+ *
+ * @author Roger Grantham
+ */
+public class MarkdownPathResolver {
+
+	/**
+	 * Not to be instantiated
+	 */
+	private MarkdownPathResolver() {
+		// no op
+	}
+
+	/**
+	 * Makes a simple attempt to convert the URL into a VirtualFile
+	 * @param target url from which a VirtualFile is sought
+	 * @return VirtualFile or null
+	 */
+	public static VirtualFile findVirtualFile(URL target){
+		VirtualFileSystem vfs = VirtualFileManager.getInstance().getFileSystem(target.getProtocol());
+		final AsyncResult<DataContext> dataContext = DataManager.getInstance().getDataContextFromFocus();
+		final Project project = DataKeys.PROJECT.getData(dataContext.getResult());
+		return  vfs.findFileByPath(target.getFile());
+	}
+
+	/**
+	 * Interprets <var>target</var> as a path relative to the currently active editor
+	 * @param target relative path from which a VirtualFile is sought
+	 * @return VirtualFile or null
+	 */
+	public static VirtualFile resolveRelativePath(String target){
+		final AsyncResult<DataContext> dataContextResult = DataManager.getInstance().getDataContextFromFocus();
+		final DataContext dataContext = dataContextResult.getResult();
+		Project project;
+		if (dataContext == null){
+			final Project[] opened = ProjectManager.getInstance().getOpenProjects();
+			if (opened.length == 0){
+				return null;
+			} else {
+				project = opened[0];
+			}
+		} else {
+			project = DataKeys.PROJECT.getData(dataContext);
+		}
+		VirtualFile virtualTarget;
+		// treat as relative
+		final VirtualFile[] selected = FileEditorManager.getInstance(project).getSelectedFiles();
+		if (selected.length == 0){
+			// no such file, but not sure how this could happen
+			return null;
+		}
+		virtualTarget = target.matches("^[.][.]")
+						? selected[0].findFileByRelativePath(target)
+						: selected[0].getParent().findFileByRelativePath(target); //if a sibling or lower in tree, query from parent
+		return virtualTarget;
+	}
+
+
+	/**
+	 * Interprets <var>target</var> as a class reference
+	 * @param target from which a VirtualFile is sought
+	 * @return VirtualFile or null
+	 */
+	public static VirtualFile resolveClassReference(String target){
+		final AsyncResult<DataContext> dataContext = DataManager.getInstance().getDataContextFromFocus();
+		final Project project = DataKeys.PROJECT.getData(dataContext.getResult());
+		if (project == null){
+			return null;
+		}
+		final PsiClass classpathResource = JavaPsiFacade.getInstance(project).findClass(target, GlobalSearchScope.projectScope(project));
+		VirtualFile virtualTarget = null;
+		if (classpathResource != null) {
+			virtualTarget = classpathResource.getContainingFile().getVirtualFile();
+		}
+		return virtualTarget;
+	}
+
+}

--- a/src/main/java/net/nicoulaj/idea/markdown/editor/MarkdownPreviewEditor.java
+++ b/src/main/java/net/nicoulaj/idea/markdown/editor/MarkdownPreviewEditor.java
@@ -31,7 +31,6 @@ import com.intellij.openapi.fileEditor.FileEditorState;
 import com.intellij.openapi.fileEditor.FileEditorStateLevel;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.UserDataHolderBase;
-import com.intellij.ui.BrowserHyperlinkListener;
 import com.intellij.ui.components.JBScrollPane;
 import net.nicoulaj.idea.markdown.MarkdownBundle;
 import net.nicoulaj.idea.markdown.settings.MarkdownGlobalSettings;
@@ -105,13 +104,14 @@ public class MarkdownPreviewEditor extends UserDataHolderBase implements FileEdi
         this.document.addDocumentListener(new DocumentPreviewUpdateListener());
 
         // Setup the editor pane for rendering HTML.
-        final HTMLEditorKit kit = new HTMLEditorKit();
+        final HTMLEditorKit kit = new MarkdownEditorKit();
         final StyleSheet style = new StyleSheet();
         style.importStyleSheet(MarkdownPreviewEditor.class.getResource(PREVIEW_STYLESHEET_PATH));
         kit.setStyleSheet(style);
         jEditorPane.setEditorKit(kit);
         jEditorPane.setEditable(false);
-        jEditorPane.addHyperlinkListener(new BrowserHyperlinkListener());
+		// add a link listener which can resolve local link references
+        jEditorPane.addHyperlinkListener(new MarkdownLinkListener());
     }
 
     /**


### PR DESCRIPTION
Added support for opening relative link targets in a new editor window and resolving relative image source paths, e.g.

```
- local relative link: [./preview.css](./preview.css)`
- local relative link: [./localization/strings.properties](./localization/strings.properties)
- classpath reference: [net.nicoulaj.idea.markdown.editor.MarkdownLinkListener](net.nicoulaj.idea.markdown.editor.MarkdownLinkListener)

- Image: ![My image](./markdown.png)
```
