### PR TITLE
Explicitly pass correct project for resource resolution.

### DIFF
--- a/src/main/java/net/nicoulaj/idea/markdown/editor/MarkdownLinkListener.java
+++ b/src/main/java/net/nicoulaj/idea/markdown/editor/MarkdownLinkListener.java
@@ -20,12 +20,8 @@
  */
 package net.nicoulaj.idea.markdown.editor;
 
-import com.intellij.ide.DataManager;
-import com.intellij.openapi.actionSystem.DataContext;
-import com.intellij.openapi.actionSystem.DataKeys;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.AsyncResult;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.openapi.vfs.ex.http.HttpFileSystem;
@@ -59,6 +55,12 @@ public class MarkdownLinkListener implements HyperlinkListener {
      */
     final BrowserHyperlinkListener browserLinkListener = new BrowserHyperlinkListener();
 
+    private final Project project;
+
+    public MarkdownLinkListener(Project project) {
+        this.project = project;
+    }
+
     /**
      * Handle hypertext link update.
      * <p/>
@@ -81,11 +83,9 @@ public class MarkdownLinkListener implements HyperlinkListener {
             if (VirtualFileManager.getInstance().getFileSystem(target.getProtocol()) instanceof HttpFileSystem) {
                 browserLinkListener.hyperlinkUpdate(e);
             } else {
-                final AsyncResult<DataContext> dataContext = DataManager.getInstance().getDataContextFromFocus();
-                final Project project = DataKeys.PROJECT.getData(dataContext.getResult());
                 VirtualFile virtualTarget = findVirtualFile(target);
                 if (virtualTarget == null || !virtualTarget.exists()) {
-                    virtualTarget = resolveRelativePath(e.getDescription());
+                    virtualTarget = resolveRelativePath(project, e.getDescription());
                 }
 
                 if (virtualTarget == null) { // Okay, try as if the link target is a class reference

--- a/src/main/java/net/nicoulaj/idea/markdown/editor/MarkdownPathResolver.java
+++ b/src/main/java/net/nicoulaj/idea/markdown/editor/MarkdownPathResolver.java
@@ -25,7 +25,6 @@ import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.actionSystem.DataKeys;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.util.AsyncResult;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileManager;
@@ -59,31 +58,18 @@ public class MarkdownPathResolver {
      */
     public static VirtualFile findVirtualFile(URL target) {
         VirtualFileSystem vfs = VirtualFileManager.getInstance().getFileSystem(target.getProtocol());
-        final AsyncResult<DataContext> dataContext = DataManager.getInstance().getDataContextFromFocus();
-        final Project project = DataKeys.PROJECT.getData(dataContext.getResult());
         return vfs.findFileByPath(target.getFile());
     }
 
     /**
      * Interprets <var>target</var> as a path relative to the currently active editor.
      *
+     *
+     * @param project the project to look for files in
      * @param target relative path from which a VirtualFile is sought
      * @return VirtualFile or null
      */
-    public static VirtualFile resolveRelativePath(String target) {
-        final AsyncResult<DataContext> dataContextResult = DataManager.getInstance().getDataContextFromFocus();
-        final DataContext dataContext = dataContextResult.getResult();
-        Project project;
-        if (dataContext == null) {
-            final Project[] opened = ProjectManager.getInstance().getOpenProjects();
-            if (opened.length == 0) {
-                return null;
-            } else {
-                project = opened[0];
-            }
-        } else {
-            project = DataKeys.PROJECT.getData(dataContext);
-        }
+    public static VirtualFile resolveRelativePath(Project project, String target) {
         VirtualFile virtualTarget;
         // treat as relative
         final VirtualFile[] selected = FileEditorManager.getInstance(project).getSelectedFiles();

--- a/src/main/java/net/nicoulaj/idea/markdown/editor/MarkdownPreviewEditor.java
+++ b/src/main/java/net/nicoulaj/idea/markdown/editor/MarkdownPreviewEditor.java
@@ -29,6 +29,7 @@ import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.fileEditor.FileEditorLocation;
 import com.intellij.openapi.fileEditor.FileEditorState;
 import com.intellij.openapi.fileEditor.FileEditorStateLevel;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.UserDataHolderBase;
 import com.intellij.ui.components.JBScrollPane;
@@ -97,9 +98,10 @@ public class MarkdownPreviewEditor extends UserDataHolderBase implements FileEdi
     /**
      * Build a new instance of {@link MarkdownPreviewEditor}.
      *
-     * @param document the {@link Document} previewed in this editor.
+     * @param project the {@link Project} containing the document
+     * @param document the {@link com.intellij.openapi.editor.Document} previewed in this editor.
      */
-    public MarkdownPreviewEditor(@NotNull Document document) {
+    public MarkdownPreviewEditor(Project project, @NotNull Document document) {
         this.document = document;
 
         // Listen to the document modifications.
@@ -119,7 +121,7 @@ public class MarkdownPreviewEditor extends UserDataHolderBase implements FileEdi
         });
 
         // Setup the editor pane for rendering HTML.
-        final HTMLEditorKit kit = new MarkdownEditorKit();
+        final HTMLEditorKit kit = new MarkdownEditorKit(project);
         final StyleSheet style = new StyleSheet();
         style.importStyleSheet(MarkdownPreviewEditor.class.getResource(PREVIEW_STYLESHEET_PATH));
         kit.setStyleSheet(style);
@@ -127,7 +129,7 @@ public class MarkdownPreviewEditor extends UserDataHolderBase implements FileEdi
         jEditorPane.setEditable(false);
 
         // Add a custom link listener which can resolve local link references.
-        jEditorPane.addHyperlinkListener(new MarkdownLinkListener());
+        jEditorPane.addHyperlinkListener(new MarkdownLinkListener(project));
     }
 
     /**

--- a/src/main/java/net/nicoulaj/idea/markdown/editor/MarkdownPreviewEditorProvider.java
+++ b/src/main/java/net/nicoulaj/idea/markdown/editor/MarkdownPreviewEditorProvider.java
@@ -65,7 +65,7 @@ public class MarkdownPreviewEditorProvider implements FileEditorProvider {
      */
     @NotNull
     public FileEditor createEditor(@NotNull Project project, @NotNull VirtualFile file) {
-        return new MarkdownPreviewEditor(FileDocumentManager.getInstance().getDocument(file));
+        return new MarkdownPreviewEditor(project, FileDocumentManager.getInstance().getDocument(file));
     }
 
     /**


### PR DESCRIPTION
This patch fixes a bug in local image resolution in the preview view. Since the project was not correctly calculated, images would show up as broken links when multiple projects were open.
